### PR TITLE
chore(submodule): add OpenCL-CTS submodule 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,3 +26,6 @@
 [submodule "cyclesim"]
 	path = cyclesim
 	url = https://github.com/THU-DSP-LAB/ventus-gpgpu-cpp-simulator.git
+[submodule "OpenCL-CTS"]
+	path = OpenCL-CTS
+	url = https://github.com/THU-DSP-LAB/OpenCL-CTS.git


### PR DESCRIPTION
Submodule:
Add OpenCL-CTS submodule, default to dev-ventus.
Update .gitmodules and record the gitlink; standardize init via make init.
Purpose: enable reproducible OpenCL-CTS builds and tests within this repo.
Docs:
Add “OpenCL-CTS Testing” with cmake examples (CL_INCLUDE_DIR/CL_LIB_DIR/OPENCL_LIBRARIES), Release/Debug.
Running examples: single tests and kernel-filtered runs (e.g., atomics/atomic_add).
Parallel: run_test_parallel.py usage (--json/--max-workers) for batch execution.
Logging: recommend tee to persist outputs for traceability.